### PR TITLE
Feature: Add a method for returning all results

### DIFF
--- a/docs/pyevr.rst
+++ b/docs/pyevr.rst
@@ -11,6 +11,14 @@ Subpackages
 Submodules
 ----------
 
+pyevr.apis module
+-----------------
+
+.. automodule:: pyevr.apis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pyevr.client module
 -------------------
 

--- a/openapi/update_schema.sh
+++ b/openapi/update_schema.sh
@@ -4,5 +4,20 @@ docker-entrypoint.sh generate -i $1 -g python -o /openapi
 find /openapi/openapi_client -type f -exec sed -i 's/openapi_client.models/pyevr.openapi_client.models/g' {} +
 find /openapi/openapi_client -type f -exec sed -i 's/from openapi_client/from pyevr.openapi_client/g' {} +
 
+# Update WaybillsApi to use waybills_list instead of waybills_get and waybills_get instead of waybills_get2
+find /openapi -type f -exec sed -i -re 's/waybills_get\(/waybills_list\(/' {} +
+find /openapi -type f -exec sed -i -re 's/waybills_get\)/waybills_list\)/' {} +
+find /openapi -type f -exec sed -i -re 's/waybills_get\*/waybills_list\*/' {} +
+find /openapi -type f -exec sed -i -re 's/waybills_get:/waybills_list:/' {} +
+find /openapi -type f -exec sed -i -re 's/waybills_get"/waybills_list"/' {} +
+find /openapi -type f -exec sed -i -re 's/waybills_get_with_http_info\(/waybills_list_with_http_info\(/' {} +
+find /openapi -type f -exec sed -i -re 's/waybills_get2\(/waybills_get\(/' {} +
+find /openapi -type f -exec sed -i -re 's/waybills_get2\)/waybills_get\)/' {} +
+find /openapi -type f -exec sed -i -re 's/waybills_get2\*/waybills_get\*/' {} +
+find /openapi -type f -exec sed -i -re 's/waybills_get2:/waybills_get:/' {} +
+find /openapi -type f -exec sed -i -re 's/waybills_get2"/waybills_get"/' {} +
+find /openapi -type f -exec sed -i -re 's/waybills_get2`/waybills_get`/' {} +
+find /openapi -type f -exec sed -i -re 's/waybills_get2_with_http_info\(/waybills_get_with_http_info\(/' {} +
+
 # Remove trailing whitespaces
 find /openapi/openapi_client -type f -exec sed -i -re 's/[ \t]+$$//' {} +

--- a/pyevr/apis.py
+++ b/pyevr/apis.py
@@ -1,0 +1,77 @@
+from math import ceil
+from typing import Callable
+
+from pyevr.openapi_client import api
+
+
+class AllMixin:
+    """Mixin for API endpoint classes to have an all() method for returning objects from all pages.
+
+    :attr list_endpoint_attr: API endpoint's method for returning paged results
+    :attr evr_page_param: Argument name that determines the page number
+    """
+
+    list_endpoint_attr = None
+    evr_page_param = 'page'
+
+    def get_list_endpoint(self) -> Callable:
+        """Method for getting the callable API's endpoint that is responsible for returning paged results
+
+        :return: Callable API's list endpoint method.
+        """
+        if self.list_endpoint_attr is None:
+            raise ValueError("AllMixin requires `list_endpoint_attr` to be set")
+        if not hasattr(self, self.list_endpoint_attr):
+            raise ValueError(f"{self.__class__} does not have the required list attribute `{self.list_endpoint_attr}`")
+        return getattr(self, self.list_endpoint_attr)
+
+    def all(self, **kwargs):
+        """Method for going through all the pages of a list view that is responsible for returning paged results"""
+        if self.evr_page_param in kwargs:
+            del kwargs[self.evr_page_param]
+        endpoint = self.get_list_endpoint()
+
+        kwargs[self.evr_page_param] = 1
+        first_page_response = endpoint(**kwargs)
+        results: list = first_page_response.page_result
+        page_size = first_page_response.page_size
+        total_count = first_page_response.total_count
+
+        if total_count <= page_size:
+            return results
+
+        total_pages = ceil(total_count / page_size)
+        for page in range(2, total_pages + 1):
+            kwargs[self.evr_page_param] = page
+            page_response = endpoint(**kwargs)
+            results.extend(page_response.page_result)
+
+        return results
+
+
+class AssortmentsAPI(AllMixin, api.AssortmentsApi):
+    list_endpoint_attr = 'assortments_list'
+
+
+class CertificatesAPI(AllMixin, api.CertificatesApi):
+    list_endpoint_attr = 'certificates_list'
+
+
+class MeasurementsAPI(AllMixin, api.MeasurementsApi):
+    list_endpoint_attr = 'measurements_get'
+
+
+class MeasurementUnitsAPI(AllMixin, api.MeasurementUnitsApi):
+    list_endpoint_attr = 'measurement_units_list'
+
+
+class OrganizationsAPI(AllMixin, api.OrganizationsApi):
+    list_endpoint_attr = 'organizations_list'
+
+
+class PlaceOfDeliveriesAPI(AllMixin, api.PlaceOfDeliveriesApi):
+    list_endpoint_attr = 'place_of_deliveries_list'
+
+
+class WaybillsAPI(AllMixin, api.WaybillsApi):
+    list_endpoint_attr = 'waybills_list'

--- a/pyevr/client.py
+++ b/pyevr/client.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 
 """Main module."""
+from pyevr import apis
 from pyevr.openapi_client.api_client import ApiClient
 from pyevr.openapi_client.configuration import Configuration
-from pyevr.openapi_client.api import (
-    AssortmentsApi, CertificatesApi, MeasurementsApi, MeasurementUnitsApi,
-    OrganizationsApi, PlaceOfDeliveriesApi, WaybillsApi,
-)
 
 
 class EVRClient(object):
@@ -22,10 +19,10 @@ class EVRClient(object):
             configuration.host = host
         self.openapi_client = ApiClient(configuration)
 
-        self.assortments = AssortmentsApi(self.openapi_client)
-        self.certificates = CertificatesApi(self.openapi_client)
-        self.measurements = MeasurementsApi(self.openapi_client)
-        self.measurement_units = MeasurementUnitsApi(self.openapi_client)
-        self.organizations = OrganizationsApi(self.openapi_client)
-        self.place_of_deliveries = PlaceOfDeliveriesApi(self.openapi_client)
-        self.waybills = WaybillsApi(self.openapi_client)
+        self.assortments = apis.AssortmentsAPI(self.openapi_client)
+        self.certificates = apis.CertificatesAPI(self.openapi_client)
+        self.measurements = apis.MeasurementsAPI(self.openapi_client)
+        self.measurement_units = apis.MeasurementUnitsAPI(self.openapi_client)
+        self.organizations = apis.OrganizationsAPI(self.openapi_client)
+        self.place_of_deliveries = apis.PlaceOfDeliveriesAPI(self.openapi_client)
+        self.waybills = apis.WaybillsAPI(self.openapi_client)

--- a/pyevr/docs/WaybillsApi.md
+++ b/pyevr/docs/WaybillsApi.md
@@ -7,8 +7,8 @@ Method | HTTP request | Description
 [**waybills_add_shipments**](WaybillsApi.md#waybills_add_shipments) | **POST** /api/waybills/{number}/shipments | Veoselehele veose lisamine
 [**waybills_cancel**](WaybillsApi.md#waybills_cancel) | **POST** /api/waybills/{number}/cancel | Veoselehe tühistamine
 [**waybills_finish**](WaybillsApi.md#waybills_finish) | **POST** /api/waybills/{number}/finish | Veoselehe lõpetamine
-[**waybills_get**](WaybillsApi.md#waybills_get) | **GET** /api/waybills | Veoselehtede pärimine
-[**waybills_get2**](WaybillsApi.md#waybills_get2) | **GET** /api/waybills/{number} | Veoselehe pärimine
+[**waybills_list**](WaybillsApi.md#waybills_list) | **GET** /api/waybills | Veoselehtede pärimine
+[**waybills_get**](WaybillsApi.md#waybills_get) | **GET** /api/waybills/{number} | Veoselehe pärimine
 [**waybills_post**](WaybillsApi.md#waybills_post) | **POST** /api/waybills | Veoselehe loomine
 [**waybills_unload**](WaybillsApi.md#waybills_unload) | **POST** /api/waybills/{number}/unload | Veoselehel veo lõpetamine
 
@@ -218,8 +218,8 @@ void (empty response body)
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **waybills_get**
-> PagedResultOfWaybill waybills_get(created_after=created_after, created_before=created_before, last_modified_after=last_modified_after, status=status, owner_code=owner_code, transporter_code=transporter_code, receiver_code=receiver_code, van_registration_number=van_registration_number, trailer_registration_number=trailer_registration_number, text=text, sort=sort, page=page, evr_language=evr_language)
+# **waybills_list**
+> PagedResultOfWaybill waybills_list(created_after=created_after, created_before=created_before, last_modified_after=last_modified_after, status=status, owner_code=owner_code, transporter_code=transporter_code, receiver_code=receiver_code, van_registration_number=van_registration_number, trailer_registration_number=trailer_registration_number, text=text, sort=sort, page=page, evr_language=evr_language)
 
 Veoselehtede pärimine
 
@@ -260,10 +260,10 @@ evr_language = 'evr_language_example' # str | Defineerib keele tagastatavatele v
 
 try:
     # Veoselehtede pärimine
-    api_response = api_instance.waybills_get(created_after=created_after, created_before=created_before, last_modified_after=last_modified_after, status=status, owner_code=owner_code, transporter_code=transporter_code, receiver_code=receiver_code, van_registration_number=van_registration_number, trailer_registration_number=trailer_registration_number, text=text, sort=sort, page=page, evr_language=evr_language)
+    api_response = api_instance.waybills_list(created_after=created_after, created_before=created_before, last_modified_after=last_modified_after, status=status, owner_code=owner_code, transporter_code=transporter_code, receiver_code=receiver_code, van_registration_number=van_registration_number, trailer_registration_number=trailer_registration_number, text=text, sort=sort, page=page, evr_language=evr_language)
     pprint(api_response)
 except ApiException as e:
-    print("Exception when calling WaybillsApi->waybills_get: %s\n" % e)
+    print("Exception when calling WaybillsApi->waybills_list: %s\n" % e)
 ```
 
 ### Parameters
@@ -307,8 +307,8 @@ Name | Type | Description  | Notes
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
-# **waybills_get2**
-> Waybill waybills_get2(number, evr_language=evr_language)
+# **waybills_get**
+> Waybill waybills_get(number, evr_language=evr_language)
 
 Veoselehe pärimine
 
@@ -338,10 +338,10 @@ evr_language = 'evr_language_example' # str | Defineerib keele tagastatavatele v
 
 try:
     # Veoselehe pärimine
-    api_response = api_instance.waybills_get2(number, evr_language=evr_language)
+    api_response = api_instance.waybills_get(number, evr_language=evr_language)
     pprint(api_response)
 except ApiException as e:
-    print("Exception when calling WaybillsApi->waybills_get2: %s\n" % e)
+    print("Exception when calling WaybillsApi->waybills_get: %s\n" % e)
 ```
 
 ### Parameters

--- a/pyevr/openapi_client/api/waybills_api.py
+++ b/pyevr/openapi_client/api/waybills_api.py
@@ -396,13 +396,13 @@ class WaybillsApi(object):
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def waybills_get(self, **kwargs):  # noqa: E501
+    def waybills_list(self, **kwargs):  # noqa: E501
         """Veoselehtede pärimine  # noqa: E501
 
         Tagastab filtritele vastavad veoselehed. Veoselehti saavad pärida ainult nendega seotud asutused.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api.waybills_get(async_req=True)
+        >>> thread = api.waybills_list(async_req=True)
         >>> result = thread.get()
 
         :param async_req bool: execute request asynchronously
@@ -431,15 +431,15 @@ class WaybillsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        return self.waybills_get_with_http_info(**kwargs)  # noqa: E501
+        return self.waybills_list_with_http_info(**kwargs)  # noqa: E501
 
-    def waybills_get_with_http_info(self, **kwargs):  # noqa: E501
+    def waybills_list_with_http_info(self, **kwargs):  # noqa: E501
         """Veoselehtede pärimine  # noqa: E501
 
         Tagastab filtritele vastavad veoselehed. Veoselehti saavad pärida ainult nendega seotud asutused.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api.waybills_get_with_http_info(async_req=True)
+        >>> thread = api.waybills_list_with_http_info(async_req=True)
         >>> result = thread.get()
 
         :param async_req bool: execute request asynchronously
@@ -482,7 +482,7 @@ class WaybillsApi(object):
             if key not in all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method waybills_get" % key
+                    " to method waybills_list" % key
                 )
             local_var_params[key] = val
         del local_var_params['kwargs']
@@ -548,13 +548,13 @@ class WaybillsApi(object):
             _request_timeout=local_var_params.get('_request_timeout'),
             collection_formats=collection_formats)
 
-    def waybills_get2(self, number, **kwargs):  # noqa: E501
+    def waybills_get(self, number, **kwargs):  # noqa: E501
         """Veoselehe pärimine  # noqa: E501
 
         Tagastab numbrile vastava veoselehe. Veoselehte saavad pärida ainult sellega seotud asutused.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api.waybills_get2(number, async_req=True)
+        >>> thread = api.waybills_get(number, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool: execute request asynchronously
@@ -572,15 +572,15 @@ class WaybillsApi(object):
                  returns the request thread.
         """
         kwargs['_return_http_data_only'] = True
-        return self.waybills_get2_with_http_info(number, **kwargs)  # noqa: E501
+        return self.waybills_get_with_http_info(number, **kwargs)  # noqa: E501
 
-    def waybills_get2_with_http_info(self, number, **kwargs):  # noqa: E501
+    def waybills_get_with_http_info(self, number, **kwargs):  # noqa: E501
         """Veoselehe pärimine  # noqa: E501
 
         Tagastab numbrile vastava veoselehe. Veoselehte saavad pärida ainult sellega seotud asutused.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
-        >>> thread = api.waybills_get2_with_http_info(number, async_req=True)
+        >>> thread = api.waybills_get_with_http_info(number, async_req=True)
         >>> result = thread.get()
 
         :param async_req bool: execute request asynchronously
@@ -612,14 +612,14 @@ class WaybillsApi(object):
             if key not in all_params:
                 raise ApiTypeError(
                     "Got an unexpected keyword argument '%s'"
-                    " to method waybills_get2" % key
+                    " to method waybills_get" % key
                 )
             local_var_params[key] = val
         del local_var_params['kwargs']
         # verify the required parameter 'number' is set
         if self.api_client.client_side_validation and ('number' not in local_var_params or  # noqa: E501
                                                         local_var_params['number'] is None):  # noqa: E501
-            raise ApiValueError("Missing the required parameter `number` when calling `waybills_get2`")  # noqa: E501
+            raise ApiValueError("Missing the required parameter `number` when calling `waybills_get`")  # noqa: E501
 
         collection_formats = {}
 

--- a/tests/test_apis.py
+++ b/tests/test_apis.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `pyevr.apis`."""
+
+import unittest
+from collections import namedtuple
+from unittest.mock import Mock
+
+from pyevr import EVRClient
+from pyevr.apis import (
+    AllMixin, AssortmentsAPI, CertificatesAPI, MeasurementsAPI, MeasurementUnitsAPI, OrganizationsAPI,
+    PlaceOfDeliveriesAPI, WaybillsAPI,
+)
+
+
+class TestEVRClient(unittest.TestCase):
+    api_key = 'asd123'
+    host = 'https://api.evr.test'
+    list_of_apis: [AllMixin] = [
+        AssortmentsAPI,
+        CertificatesAPI,
+        MeasurementsAPI,
+        MeasurementUnitsAPI,
+        OrganizationsAPI,
+        PlaceOfDeliveriesAPI,
+        WaybillsAPI,
+    ]
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.client = EVRClient(self.api_key, self.host)
+
+    def run_api_test(self, api: AllMixin):
+        self.assertTrue(isinstance(api, AllMixin))
+        self.assertTrue(hasattr(api, api.list_endpoint_attr))
+        self.assertIsNotNone(api.get_list_endpoint())
+
+    def test_apis(self):
+        for api_class in self.list_of_apis:
+            self.run_api_test(api_class(self.client))
+
+    def run_all_mixin_test(self, data: [int]):
+        PagedResult = namedtuple('PagedResult', ['page', 'page_size', 'page_result', 'total_count'])
+
+        def assortments_list(page):
+            index_increment = (page - 1) * 3
+            return PagedResult(
+                page, 3, data[0 + index_increment:3 + index_increment], len(data),
+            )
+
+        api = AssortmentsAPI(self.client)
+        api.assortments_list = Mock(side_effect=assortments_list)
+        self.assertListEqual(api.all(), data)
+        # Pass in a random page to make sure that it does not have any effect
+        self.assertListEqual(api.all(page=99), data)
+
+    def test_all_mixin(self):
+        with self.assertRaises(ValueError):
+            api = AssortmentsAPI(self.client)
+            api.list_endpoint_attr = None
+            api.get_list_endpoint()
+
+        with self.assertRaises(ValueError):
+            api = AssortmentsAPI(self.client)
+            api.list_endpoint_attr = 'random_method'
+            api.get_list_endpoint()
+
+        self.run_all_mixin_test([])
+        self.run_all_mixin_test([1])
+        self.run_all_mixin_test([1, 2, 3])
+        self.run_all_mixin_test([1, 2, 3, 4, 5, 6, 7, 8])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -26,14 +26,23 @@ class TestEVRClient(unittest.TestCase):
         self.assertEqual(client.openapi_client.configuration.host, 'https://evr-test.azurewebsites.net')
 
     def test_api_groups(self):
+        from pyevr import apis
+        self.assertEqual(type(self.client.assortments), apis.AssortmentsAPI)
+        self.assertEqual(type(self.client.certificates), apis.CertificatesAPI)
+        self.assertEqual(type(self.client.measurements), apis.MeasurementsAPI)
+        self.assertEqual(type(self.client.measurement_units), apis.MeasurementUnitsAPI)
+        self.assertEqual(type(self.client.organizations), apis.OrganizationsAPI)
+        self.assertEqual(type(self.client.place_of_deliveries), apis.PlaceOfDeliveriesAPI)
+        self.assertEqual(type(self.client.waybills), apis.WaybillsAPI)
+
         from pyevr.openapi_client import api
-        self.assertEqual(type(self.client.assortments), api.AssortmentsApi)
-        self.assertEqual(type(self.client.certificates), api.CertificatesApi)
-        self.assertEqual(type(self.client.measurements), api.MeasurementsApi)
-        self.assertEqual(type(self.client.measurement_units), api.MeasurementUnitsApi)
-        self.assertEqual(type(self.client.organizations), api.OrganizationsApi)
-        self.assertEqual(type(self.client.place_of_deliveries), api.PlaceOfDeliveriesApi)
-        self.assertEqual(type(self.client.waybills), api.WaybillsApi)
+        self.assertTrue(isinstance(self.client.assortments, api.AssortmentsApi))
+        self.assertTrue(isinstance(self.client.certificates, api.CertificatesApi))
+        self.assertTrue(isinstance(self.client.measurements, api.MeasurementsApi))
+        self.assertTrue(isinstance(self.client.measurement_units, api.MeasurementUnitsApi))
+        self.assertTrue(isinstance(self.client.organizations, api.OrganizationsApi))
+        self.assertTrue(isinstance(self.client.place_of_deliveries, api.PlaceOfDeliveriesApi))
+        self.assertTrue(isinstance(self.client.waybills, api.WaybillsApi))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves #24 

- Add a method for returning all of the results for EVR API's list endpoints
- Update WaybillsApi to use waybills_list instead of waybills_get and waybills_get instead of waybills_get2
